### PR TITLE
feat: Redirect to MFA setup and restrict email domain

### DIFF
--- a/js/confirmation.js
+++ b/js/confirmation.js
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (result.success) {
                     sessionStorage.removeItem('registrationData');
                     setTimeout(() => {
-                        window.location.href = 'login.html';
+                        window.location.href = 'mfa_setup.html'; // Redireciona para a configuração do MFA
                     }, 2000);
                 }
             } catch (error) {


### PR DESCRIPTION
This commit introduces two main changes to the user registration process:

1.  Email Domain Restriction: The registration API (`api/auth/register.php`) now validates that the user's email address belongs to the `@grupomysa.com.br` domain. This prevents users with other email domains from creating an account.

2.  Redirect to MFA Setup: After a successful registration, the user is now automatically logged in and redirected to the MFA setup page (`mfa_setup.html`) instead of the login page. This is achieved by creating a session for the new user on the backend and updating the frontend redirection logic in `js/confirmation.js`.